### PR TITLE
Reorder entries in changelog.html

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -101,8 +101,8 @@
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.134(572)-a929e2a @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(739)-905692603 @Github</u></a>
 <u>biz.candyhouse.co</u>
-1.androidアプリ にも、3.7V LiNixCoyMnzO2 三元系リチウム電池の時間経過に伴う電圧変化グラフをサポートしました。
-2.長押しで、管理者(マネージャーやオーナー)が履歴を削除できるようになりました。
+1.長押しで、管理者(マネージャーやオーナー)が履歴を削除できるようになりました。
+2.androidアプリ にも、3.7V LiNixCoyMnzO2 三元系リチウム電池の時間経過に伴う電圧変化グラフをサポートしました。
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/delete_history_iOSandroidBiz.png"></a>
 
 <u>Sesame Bot 2</u>


### PR DESCRIPTION
Swap two list items under 'biz.candyhouse.co' in changelog.html: move the long-press admin history deletion entry before the Android 3.7V LiNixCoyMnzO2 battery voltage-graph support entry to correct their ordering.