### PR TITLE
Add spacing and commits link to changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1830,6 +1830,8 @@ VivoKey Japan合同会社様よりご指摘をいただき、7バイトのNFCタ
 1.モーターが稼働している時にシステムがウォッチドッグにフィードしていないため、複数回転のロックが回転中に再起動してしまいます。
 </code></pre>
 
+<br><br><br>
+https://github.com/CANDY-HOUSE/.github/commits/main/changelog.html
 
 <style>
 /* スマホ対応：<pre><code>内のテキストを折り返す */


### PR DESCRIPTION
Insert three line breaks and a link to the repository's commits page into changelog.html (added just before the <style> tag). This is a non-functional formatting update to expose the GitHub commits URL for the changelog.