### PR TITLE
Make changelog URL a clickable link

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1831,7 +1831,7 @@ VivoKey Japan合同会社様よりご指摘をいただき、7バイトのNFCタ
 </code></pre>
 
 <br><br><br>
-https://github.com/CANDY-HOUSE/.github/commits/main/changelog.html
+<a href="https://github.com/CANDY-HOUSE/.github/commits/main/changelog.html" target="_blank"><u>https://github.com/CANDY-HOUSE/.github/commits/main/changelog.html</u></a>
 
 <style>
 /* スマホ対応：<pre><code>内のテキストを折り返す */


### PR DESCRIPTION
Replace the raw URL in changelog.html with an anchor tag so the link is clickable and opens in a new tab (target="_blank"). Adds an underline (<u>) for visual emphasis. Small HTML tweak to improve usability.