### PR TITLE
Reorder changelog: admin history deletion entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -35,6 +35,7 @@
 ✅<span style="color: #e3e3e3;"><s>さらにスマホアプリとスマホBluetooth性能への依存度を減らすために、Hub3やESP32などからSesameシリーズのSesameOSをアップデートできるように実現します。</s></span>
 ✅<span style="color: #e3e3e3;"><s>連絡先の並び順が自由に調整できるよう、検索もできるように実現。</s></span>
 ✅<span style="color: #e3e3e3;"><s>biz.candyhouse.co がオープンソース化しました！GitHub Actions により、公開リポジトリへ自動同期されるようになります。</s></span>
+✅<span style="color: #e3e3e3;"><s>管理者(マネージャーやオーナー)が履歴を削除できる機能。</s></span>
 </code></pre>
 <pre><code>
 ☑️Hub3＋SesameTouch+OpenSensor+Bizの正式リリース
@@ -70,8 +71,6 @@
 ☑️chat.candyhouse.coがオープンソース化へ！GitHub Actionsで公開リポジトリに自動公開されます。
 (2026年4月末の予定)
 ☑️ESP32用のオープンソースSesameSDKも、GitHub Actionsで公開リポジトリに自動公開されます。
-(2026年4月末の予定)
-☑️管理者(マネージャーやオーナー)が履歴を削除できる機能。
 (2026年4月末の予定)
 ☑️Hub3 + Remote/Remote nano + CANDY HOUSE全製品 がMatter依存せず純正連携できるように。
 (2026年4月末の予定)


### PR DESCRIPTION
Move the '管理者(マネージャーやオーナー)が履歴を削除できる機能。' item into the checked items list and remove the duplicate dated entry (the previous 2026-04末予定 lines). This eliminates duplication and keeps the changelog entry consolidated.