### PR TITLE
Add 2026-03-28 release notes to changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -96,6 +96,40 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年3月28日(土)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.134(582)-ffa3c63 @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(748)-931c5d750 @Github</u></a>
+1. 
+iOS/AndroidアプリのUI微調整、クラッシュ及びバグの修正。コードレビューを実施し、リファクタリング（整理・軽量化）を実施。
+
+
+<u>Sesame Bot 2</u>
+ 3.0-17-ad26ee
+<u>Sesame Bike 2</u>
+ 3.0-6-ad26ee
+<u>Sesame 5</u>
+ 3.0-5-ad26ee
+<u>Sesame 5 Pro</u>
+ 3.0-7-ad26ee
+<u>Sesame 5 北欧北米版</u>
+ 3.0-16-ad26ee
+<u>Open Sensor</u>
+ 3.0-8-763d18
+<u>Sesame Touch Pro / Sesame Touch 2 Pro</u>
+ 3.0-9-323190
+<u>Sesame Touch / Sesame Touch 2</u>
+ 3.0-10-323190
+
+1.
+より多くの機種にて、ユーザーご自身でBluetooth TX Power（送信強度）を自由に調整可能になりました！電波干渉が多く、Bluetoothが不安定で途切れやすい環境に最適です。接続の不安定さを効果的に解消できることが実際の検証で実証されています。
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/bot2scriptNameRankEditable_iOSandroid.png"></a>
+2.
+併せてコードレビューを実施し、リファクタリング（整理）を行いました。
+今回のBluetooth送信強度（TX Power）調整機能の追加に伴い、一度電池を抜き差ししない限りBluetoothが繋がらなくなるバグを修正しました。（原因：Bluetooth advertisingが停止してしまうバグ）
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年3月21日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.134(572)-a929e2a @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(739)-905692603 @Github</u></a>


### PR DESCRIPTION
Append 2026-03-28 entries to changelog.html: add iOS TestFlight and Android APK links, list firmware builds for multiple devices, and describe app UI tweaks, crash/bug fixes, refactoring, and a new Bluetooth TX Power adjustment feature. Also note fix for Bluetooth advertising bug that required battery removal and include illustrative image.