### PR TITLE
Hide changelog details by default

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1,5 +1,5 @@
 <h2>To Do やること</h2>
-<button style="display:block;text-align:left;" onclick="var e=document.getElementById('showOrHide');
+<button style="display:none;text-align:left;" onclick="var e=document.getElementById('showOrHide');
   if(e.style.display==='none'){
     e.style.display='block';
     this.textContent='▼できたことを折り畳む';


### PR DESCRIPTION
Change the changelog toggle button's inline style from display:block to display:none so the 'showOrHide' section is collapsed on initial load. The existing onclick toggle logic is kept to expand the section and update the button text when clicked.