### PR TITLE
Fix changelog: move SesameBot rename entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -36,6 +36,7 @@
 ✅<span style="color: #e3e3e3;"><s>連絡先の並び順が自由に調整できるよう、検索もできるように実現。</s></span>
 ✅<span style="color: #e3e3e3;"><s>biz.candyhouse.co がオープンソース化しました！GitHub Actions により、公開リポジトリへ自動同期されるようになります。</s></span>
 ✅<span style="color: #e3e3e3;"><s>管理者(マネージャーやオーナー)が履歴を削除できる機能。</s></span>
+✅<span style="color: #e3e3e3;"><s>SesameBotの台本の名称を変更できるように。</s></span>
 </code></pre>
 <pre><code>
 ☑️Hub3＋SesameTouch+OpenSensor+Bizの正式リリース
@@ -59,8 +60,6 @@
 ☑️CANDY HOUSE全製品に対して曜日指定、時間指定等のスケジュール稼働機能。例えば、オートロックの時間帯指定、夜間だけオートロック、GoogleカレンダーやSlackとの連携、期間限定のパスワード解錠とSuica解錠、ドア開いたら何分間閉めてないなら、通知が来る、など。
 (2026年3月末の予定)
 ☑️SesameBot2、SesameBike2、Open Sensor履歴及び通知機能のリリース
-(2026年3月末の予定)
-☑️SesameBotの台本の名称を変更できるように。
 (2026年3月末の予定)
 ☑️持ち去り対策機能につきましては、近日中にソフトウェアアップデートにより実現いたします。新たなハードウェアや半導体チップは一切不要です。
 具体的な実現方法としましては、万が一Sesame FaceとHub 3のBluetooth接続が途切れた際に、アプリへ通知が届く仕組みとなります。


### PR DESCRIPTION
Add a checked entry for "SesameBotの台本の名称を変更できるように" in the earlier changelog section and remove the duplicate scheduled lines (the later checkbox and its 2026/03 planned date). This cleans up a duplicated item and keeps the changelog entries consistent.