### PR TITLE
Add 2026-04-25 changelog entries

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -94,6 +94,29 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年4月25日(土)</b>
+<u>Sesame Bot 2</u>
+ 3.0-17-d3990f
+1.Bugfix: 今年の初めにSesameBot2 / SesameBike2 / Sesame5 / Sesame5 Pro / Sesame5 北欧北米版のコードベースを統合した際、SesameBot2の改修において2箇所ほど見落としがございました。その影響により、SesameBot2でBluetoothのコールバックが送信されない場合があり、スマホアプリのUIフィードバックの体験が低下する問題を修正いたしました。
+
+<u>biz.candyhouse.co</u>
+1.
+現在、Web版にて、赤い❗マークで「SesameOSの最新バージョンがございます。ぜひ更新をお願いいたします。」とユーザーにお知らせする機能を実装いたしました。
+来週中にiOS・Androidアプリにも同機能を追加予定です。
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/showNewSesameOSAvailableOnBiz.png"></a>
+
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.139(613)-c5a005c @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(776)-623c7b79e @Github</u></a>
+1.
+iOSアプリにて、サーバーからの「Sesameの低電圧のため電池交換が必要です」というプッシュ通知を受信した後に、バッテリー電圧の時系列グラフページを表示する基盤を実装いたしました。
+2.
+先週、SesameBot2をSesameFaceシリーズに対応させた際に、iOS側のUI修正漏れに対応いたしました。
+3.
+androidアプリにて、サーバーからの「Sesameの低電圧のため電池交換が必要です」というプッシュ通知を受信した後に、バッテリー電圧の時系列グラフページを表示する基盤を実装いたしました。
+
+</code></pre>
+<hr>
+<pre><code> 
 <b>2026年4月18日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.138(604)-f8892d1 @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(769)-0ba204310 @Github</u></a>
@@ -110,7 +133,7 @@ androidアプリにて、Android Gradle Plugin（AGP）を9.1.0から最新版9.
 1.SesameBot2をSesameFaceシリーズに対応させました。
 
 <u>chat.candyhouse.co</u>
-chat.candyhouse.coがオープンソース化になりました。GitHub Actionsで公開リポジトリに自動同期するようになりました。
+1.chat.candyhouse.coがオープンソース化になりました。GitHub Actionsで公開リポジトリに自動同期するようになりました。
 
 </code></pre>
 <hr>


### PR DESCRIPTION
Add changelog entries for 2026-04-25 covering Sesame Bot 2 and app updates: note a Bluetooth callback bugfix in SesameBot2 after codebase consolidation; new biz.candyhouse.co web notice for available SesameOS (with screenshot); links to iOS TestFlight and Android APK; implementations to open battery-voltage time-series graph from low-battery push notifications on iOS and Android; UI fixes for SesameFace support. Also adjust numbering/formatting for the chat.candyhouse.co entry.