### PR TITLE
Add 2026-05-16 changelog entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -93,6 +93,23 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年5月16日(土)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.142(629)-8890e4d @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(800)-68b6a6461 @Github</u></a>
+<u>biz.candyhouse.co</u>
+biz.candyhouse.co側で、iOS / Androidアプリ上でHTML5（biz.candyhouse.co）ページが読み込めなくなるバグを修正しました。
+http://github.com/CANDY-HOUSE/biz.candyhouse.co/commit/04aedc15e872726307629eb9e3642338bc446104
+
+併せて、AWS Lambdaの設定にて、MemoryおよびEphemeral storageを上限最大値である10240MBに、Timeoutも上限の900秒（15分）まで引き上げました。
+ユーザーにSwift/Kotlinとの違いを全く感じさせないパフォーマンスを期待しています。
+
+iOS / Androidアプリにおいては、未発表の新製品に関する修正を除き、変更はございません。
+何故ならSwift / Kotlinのコードの大部分を既にHTML5（biz.candyhouse.co）へ移行しており、そしてbiz.candyhouse.coは毎日更新されているからです。
+Swift / Kotlinネイティブへの信仰を手放したメリットが、少しずつ現れ始めています。
+
+</code></pre>
+<hr>
+<pre><code> 
 <b>2026年5月10日(日)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.141(627)-18f4036 @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(796)-ef49a3e1a @Github</u></a>


### PR DESCRIPTION
Insert a changelog entry for 2026-05-16 describing a fix that prevented HTML5 (biz.candyhouse.co) pages from loading in the iOS/Android apps. Includes links to the iOS TestFlight build and Android APK, and references the backend commit. Notes AWS Lambda configuration increases (Memory and Ephemeral storage to 10240MB, Timeout to 900s) to improve performance, and states there are no native app changes aside from unreleased product fixes due to migrating most Swift/Kotlin code to the HTML5 site.