### PR TITLE
Add trailing blank line in changelog.html

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -119,6 +119,7 @@ http://github.com/CANDY-HOUSE/biz.candyhouse.co/commit/04aedc15e872726307629eb9e
 ユーザーにSwift/Kotlinとの違いを全く感じさせないパフォーマンスを期待しています。
 
 iOS / Androidアプリにおいては、未発表の新製品に関する修正を除き、変更はございません。
+
 </code></pre>
 <hr>
 <pre><code> 


### PR DESCRIPTION
Insert a single blank line before the closing </code></pre> block in changelog.html to improve formatting/consistency of the rendered changelog. No functional changes.