### PR TITLE
Update changelog with 2026-05-30 entries

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -93,17 +93,38 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年5月30日(土)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.144(63?)-??????? @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(807)-28a3a89f1 @Github</u></a>
+1.
+ユーザーの陰山様からのフィードバックに感謝いたします！Androidアプリにおいて、ホーム画面のセサミリストで展開済みのSesameBot2の台本一覧上にて、セサミボットAを操作したつもりがセサミボットBをトリガーしてしまう不具合を修正いたしました。
+https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/commit/65e8a9f998784fabe1112de7f17875f40d63f3b2
+https://youtube.com/shorts/dorzSgShnhI
+
+2.
+Androidアプリにおいて、MQTT（AWS IoT）関連コードのリファクタリングおよび整理を行い、iOS側の実装方式との統一を図りました。
+現在Androidアプリ起動時にMQTTの状態（Hub3やHub3経由でのセサミ状態）は、UI上で1台ずつ順番に更新するのではなく、すべてのデバイス情報を一括で更新する方式に変更しております。これにより、状態を即時に表示できるようになり、遅延を完全になくせたかと思います ^_^
+https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/commit/cb86af7d63ccba2b49c3e9e8064aedcc8e440abd
+
+3.
+iOSアプリにおいては、未発表の新製品に関する修正を除き、変更はございません。
+何故ならSwift / Kotlinのコードの大部分を既にHTML5（biz.candyhouse.co）へ移行しており、そしてbiz.candyhouse.coは毎日更新されているからです。
+Swift / Kotlinネイティブへの信仰を手放したメリットが、少しずつ現れ始めています。
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年5月23日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.143(631)-52d26de @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(805)-67bbebfc5 @Github</u></a>
+1.
 Androidアプリにおいて、MQTT（AWS IoT）関連コードのリファクタリングおよび整理を行い、iOS側の実装方式との統一を図りました。
 目的としては、来週のアップデートで、Androidアプリ起動時にMQTTの状態（Hub3やHub3経由でのセサミ状態）を即時に表示し、遅延を完全になくすためです：
 https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/commit/edb70a110c4f836331a2773f768df18d4c48044b
 https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/commit/134900d2997d3b5f18fdd7fbffe98ab675abfeb8
 
+2.
 iOSアプリにおいては、未発表の新製品に関する修正を除き、変更はございません。
-何故ならSwift / Kotlinのコードの大部分を既にHTML5（biz.candyhouse.co）へ移行しており、そしてbiz.candyhouse.coは毎日更新されているからです。
-Swift / Kotlinネイティブへの信仰を手放したメリットが、少しずつ現れ始めています。
 
 </code></pre>
 <hr>
@@ -112,12 +133,14 @@ Swift / Kotlinネイティブへの信仰を手放したメリットが、少し
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.142(629)-8890e4d @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(800)-68b6a6461 @Github</u></a>
 <u>biz.candyhouse.co</u>
+1.
 biz.candyhouse.co側で、iOS / Androidアプリ上でHTML5（biz.candyhouse.co）ページが読み込めなくなるバグを修正しました。
 http://github.com/CANDY-HOUSE/biz.candyhouse.co/commit/04aedc15e872726307629eb9e3642338bc446104
 
 併せて、AWS Lambdaの設定にて、MemoryおよびEphemeral storageを上限最大値である10240MBに、Timeoutも上限の900秒（15分）まで引き上げました。
 ユーザーにSwift/Kotlinとの違いを全く感じさせないパフォーマンスを期待しています。
 
+2.
 iOS / Androidアプリにおいては、未発表の新製品に関する修正を除き、変更はございません。
 
 </code></pre>


### PR DESCRIPTION
Add 2026-05-30 release notes to changelog.html including iOS TestFlight and Android APK links. Document Android bug fix (SesameBot2 mis-triggering in expanded list), MQTT/AWS IoT refactor to batch device state updates (align with iOS), and note that iOS has no functional changes. Also reorganize surrounding entries to include related biz.candyhouse.co and AWS Lambda performance notes and keep prior 2026-05-23/earlier entries intact. Commit/YouTube links are included in the notes.