### PR TITLE
Update changelog: bump Android & remove iOS entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -94,8 +94,7 @@
 <h2>Change Log 変更履歴</h2>
 <pre><code>
 <b>2026年5月30日(土)</b>
-<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.144(63?)-??????? @TestFlight</u></a>
-<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(807)-28a3a89f1 @Github</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(808)-b2252c00d @Github</u></a>
 1.
 ユーザーの陰山様からのフィードバックに感謝いたします！Androidアプリにおいて、ホーム画面のセサミリストで展開済みのSesameBot2の台本一覧上にて、セサミボットAを操作したつもりがセサミボットBをトリガーしてしまう不具合を修正いたしました。
 https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/commit/65e8a9f998784fabe1112de7f17875f40d63f3b2
@@ -105,11 +104,6 @@ https://youtube.com/shorts/dorzSgShnhI
 Androidアプリにおいて、MQTT（AWS IoT）関連コードのリファクタリングおよび整理を行い、iOS側の実装方式との統一を図りました。
 現在Androidアプリ起動時にMQTTの状態（Hub3やHub3経由でのセサミ状態）は、UI上で1台ずつ順番に更新するのではなく、すべてのデバイス情報を一括で更新する方式に変更しております。これにより、状態を即時に表示できるようになり、遅延を完全になくせたかと思います ^_^
 https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/commit/cb86af7d63ccba2b49c3e9e8064aedcc8e440abd
-
-3.
-iOSアプリにおいては、未発表の新製品に関する修正を除き、変更はございません。
-何故ならSwift / Kotlinのコードの大部分を既にHTML5（biz.candyhouse.co）へ移行しており、そしてbiz.candyhouse.coは毎日更新されているからです。
-Swift / Kotlinネイティブへの信仰を手放したメリットが、少しずつ現れ始めています。
 
 </code></pre>
 <hr>


### PR DESCRIPTION
Update changelog.html to point Android app to 3.0.266(808)-b2252c00d (updated download link/hash) and remove the iOS TestFlight link and the obsolete note about iOS/native changes. Cleans up changelog entries to reflect the current Android build and remove outdated iOS remarks.