### PR TITLE
Add 2026-06-06 changelog entries

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -95,6 +95,43 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年6月6日(土)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.144(637)-bf5ce7e @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(814)-8ab7f8d70 @Github</u></a>
+1. 【Android app】Gradleを最新バージョン（9.5.0）へアップデートしました。
+2. 【Android app】Linux/macOS/WindowsにおけるJDKツールチェーン等のバージョンと設定をコードで管理するようにしました。
+3. 【Android app & iOS app】Hub3のSesameOSアップデート後、ホーム画面のデバイスリストで赤いビックリマーク（！）が消えない不具合を修正しました。
+4. 【Android app】各画面の赤色Bluetooth警告バーを、常に最上部へ固定表示するよう統一しました。
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/Screenshot_20260606-012547.png"></a>
+
+5. 【iOS app】Open Sensorシリーズの操作履歴機能を実装しました。
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/OpenSensorHisotryPage_iOS.png"></a>
+
+<u>Sesame Face Pro</u>
+ 3.0-18-3ca817
+<u>Sesame Face</u>
+ 3.0-19-3ca817
+<u>Sesame Face Pro AI時代版</u>
+ 3.0-22-3ca817
+<u>Sesame Face AI時代版</u>
+ 3.0-23-3ca817
+<u>Sesame Touch Pro / Sesame Touch 2 Pro</u>
+ 3.0-9-3ca817
+<u>Sesame Touch / Sesame Touch 2</u>
+ 3.0-10-3ca817
+<b>【!重要アップデート!】1. 上記機種におけるBluetoothの未アドバタイズ・未接続の不具合を修正しました。
+（詳細な原因と対応：BLE接続の初期化時にアドバタイズコマンドを同時に実行すると、RivieraWavesカーネルのBluetooth処理が完全に停止し、接続および他デバイスへの自発的な接続が行えなくなる問題を特定・修正しました。この現象は、複数デバイスのBluetooth接続によりシステムが高負荷な場合や、Hub3のネットワークが不安定で上記機種のBluetoothへの再接続を繰り返す環境下で発生しやすくなっていました。）</b>
+2. SesameOSアップデート(DFU)時のBluetooth通信速度を最大化しました。
+3. Bluetooth認証（クレデンシャル）エラーのコールバックコードに対応しました。
+これにより、将来的にSesame本体がリセットされた際、上記機種側から対象のSesameデバイスを自動的（自発的）に削除できるようになります。
+4. BLEアドバタイズにフラグを追加し、「SesameOSアップデート中」のステータスを発信するようにしました。
+5. BLEホワイトリストへSesameが重複して追加されるのを防ぐため、重複チェック処理を追加しました。
+6. 青色および赤色LEDが確実に同時消灯するよう、led_off 関数を修正しました。
+7. コードのリファクタリング（不要なコードの削除・整理）を行いました。
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年5月30日(土)</b>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(808)-b2252c00d @Github</u></a>
 1.


### PR DESCRIPTION
Insert changelog entry for 2026-06-06 with TestFlight and Android release links. Documents Android changes (Gradle 9.5.0 update, JDK toolchain/version management), UI fixes (red Bluetooth warning bar pinned), Hub3/SesameOS bug fixes (red exclamation on device list), iOS Open Sensor history feature, firmware version listings for multiple devices, and several BLE/DFU/LED fixes and refactors. Adds screenshots to illustrate changes.