### PR TITLE
Add 2026-06-13 changelog entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -95,6 +95,18 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年6月13日(土)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.145(641)-baeb302 @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(818)-a57302aeb @Github</u></a>
+1. 【Android app】オープンソースであるため、コード難読化を行う必要がないため、ProGuard 内のコード難読化設定をすべて削除しました。あわせて、コード量も削減しました。
+<b>2. 【Android app & iOS app】UIコード側にて、Faceシリーズのレーダー検知距離を最長1メートルに制限させて頂きました。レーダーの検知距離を長く設定しすぎると、ちょっとした風による僅かな草の揺れにも過敏に反応し、『顔・静脈認証』が起動してしまうことが実験で分かりました。
+ユーザーの皆様の電池がすぐ減ってしまう一番の原因でした。</b>
+3. 【Android app & iOS app】Bluetoothを使用する全てのUI画面の最上部に、Bluetooth状態異常を知らせる「赤色の警告バー」を追加しました。6年前にやっておくべきことでした。
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/Screenshot_20260606-012547.png"></a>
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年6月6日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.144(637)-bf5ce7e @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(814)-8ab7f8d70 @Github</u></a>


### PR DESCRIPTION
Add changelog entry for 2026-06-13 including iOS TestFlight and Android GitHub release links. Notes removal of Android ProGuard obfuscation settings (open-source), reduction of code size, restriction of Face series radar detection to 1 meter to prevent false activations and save battery, and addition of a red Bluetooth warning bar at the top of all Bluetooth UI screens plus a screenshot. Inserted a horizontal rule to separate entries.