### PR TITLE
Update changelog: clarify Bluetooth warning bar

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -100,7 +100,7 @@
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(818)-a57302aeb @Github</u></a>
 1.【Android app】オープンソースであるため、コード難読化を行う必要がないため、ProGuard 内のコード難読化設定をすべて削除しました。あわせて、コード量も削減しました。
 <b>2.【重要アップデート】【Android app & iOS app】UIコード側にて、Faceシリーズのレーダー検知距離を最長1メートルに制限させて頂きました。レーダーの検知距離を長く設定しすぎると、ちょっとした風による僅かな草の揺れにも過敏に反応し、『顔・静脈認証』が起動してしまうことが実験で分かりました。ユーザーの皆様の電池がすぐ減ってしまう一番の原因でした。</b>
-3.【Android app & iOS app】Bluetoothを使用する全てのUI画面の最上部に、Bluetooth状態異常を知らせる「赤色の警告バー」を追加しました。6年前にやっておくべきことでした。
+3.【Android app & iOS app】Bluetoothを使用する全てのUI画面の最上部に、Bluetooth状態異常を知らせる「赤色の警告バー」を補完しました（実装漏れだった画面への補完）。6年前にやっておくべきことでした。
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/Screenshot_20260606-012547.png"></a>
 
 </code></pre>


### PR DESCRIPTION
Edit changelog.html to refine the Japanese entry about the red Bluetooth warning bar: changed wording from "added" to "補完しました（実装漏れだった画面への補完）" to indicate the bar was supplemented for screens that were previously missed. This is a documentation wording clarification, not a functional change.