### PR TITLE
Add 2026-06-27 changelog entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -95,6 +95,33 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年6月27日(火)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(6??)-??????? @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(8??)-??????? @Github</u></a>
+1. SesameBot2、SesameBike2における履歴及び通知機能が完成。
+2.
+<img src=""></a>
+
+
+<u>Sesame Face Pro</u>
+ 3.0-18-dec54c
+<u>Sesame Face</u>
+ 3.0-19-dec54c
+<u>Sesame Face Pro AI時代版</u>
+ 3.0-22-dec54c
+<u>Sesame Face AI時代版</u>
+ 3.0-23-dec54c
+<u>Sesame Touch Pro / Sesame Touch 2 Pro</u>
+ 3.0-9-dec54c
+<u>Sesame Touch / Sesame Touch 2</u>
+ 3.0-10-dec54c
+<b>1. 【重要アップデート】</b>
+<b>2. 【重要アップデート】</b>
+<img src=""></a>
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年6月19日(金)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.146(647)-0b9be93 @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(824)-170d6efdd @Github</u></a>


### PR DESCRIPTION
Insert new changelog section for 2026-06-27 including iOS TestFlight and Android GitHub download links, device build numbers for multiple Sesame models, and a note that history and notification features for SesameBot2 and SesameBike2 are completed. Adds placeholders for images and marks two important updates.