### PR TITLE
Changelog: mark Bot2/Bike2/OpenSensor done

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -39,10 +39,9 @@
 ✅<span style="color: #e3e3e3;"><s>SesameBotの台本の名称を変更できるように。</s></span>
 ✅<span style="color: #e3e3e3;"><s>chat.candyhouse.coがオープンソース化へ！GitHub Actionsで公開リポジトリに自動公開されます。</s></span>
 ✅<span style="color: #e3e3e3;"><s>全製品において、縦軸を電圧、横軸を時間とするグラフを作成し、数日と数ヶ月にわたりデータを収集・分析することで、電池残量の表示精度を99％に限りなく近づけ、突然異常な電圧低下が発生した場合、即座に通知を送信。また、全製品において、SesameOSバージョンの状態をリアルタイムで記録し、SesameOSの新バージョンがリリースされると、メール又は通知が届く。</s></span>
+✅<span style="color: #e3e3e3;"><s>SesameBot2、SesameBike2、Open Sensorにおける履歴及び通知機能</s></span>
 </code></pre>
 <pre><code>
-☑️SesameBot2、SesameBike2、Open Sensorにおける履歴及び通知機能
-(2026年6月末の予定)
 ☑️Hub3＋SesameTouch+OpenSensor+Bizの正式リリース
   ✅<span style="color: #e3e3e3;"><s>①Hub3はほとんどの操作でBluetoothが不要なため、次はBluetooth経由でWiFiパスワード設定UI以外の全てのUIをKotlin/SwiftからHTML5に移行します。
 メリットは、アプリ保守コストを90%削減でき、Web操作もできるようになる点です。</s></span>
@@ -98,9 +97,9 @@
 <b>2026年6月27日(火)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(6??)-??????? @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(8??)-??????? @Github</u></a>
-1. SesameBot2、SesameBike2における履歴及び通知機能が完成。
-2.
-<img src=""></a>
+1. 
+2. SesameBot2、SesameBike2における履歴の通知機能が完成。
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/SesameBot2_Bike2_Bike3HistoryNotificationOniOSandroid.png"></a>
 
 
 <u>Sesame Face Pro</u>


### PR DESCRIPTION
Update changelog.html to reflect completion of history/notification features for SesameBot2, SesameBike2, and Open Sensor. Removed the planned schedule line, adjusted the release note bullets wording, and added an image link for the Bot2/Bike2 history notification screenshot.