### PR TITLE
Update changelog for Face2 radar adjustments

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -94,10 +94,10 @@
 <p><br><br><br></p>
 <h2>Change Log 変更履歴</h2>
 <pre><code>
-<b>2026年6月27日(火)</b>
+<b>2026年6月27日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(6??)-??????? @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(8??)-??????? @Github</u></a>
-1. 
+<b>1.【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
 2. SesameBot2、SesameBike2における履歴の通知機能が完成。
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/SesameBot2_Bike2_Bike3HistoryNotificationOniOSandroid.png"></a>
 
@@ -115,7 +115,9 @@
 <u>Sesame Touch / Sesame Touch 2</u>
  3.0-10-dec54c
 <b>1. 【重要アップデート】</b>
-<b>2. 【重要アップデート】</b>
+<b>2. 【重要アップデート】Face2シリーズのレーダーパラメータ（ESD静電気対策済みレーダー）につきまして、黄色の曲線のようにパラメータを再調整いたしました。
+曲線をより線形に近づけるとともに、1メートル以内でごく稀に発生していた自己励起問題を根本的に解決しました。
+弊社の実験により、従来の設定では、ちょっとした風による草のわずかな揺れにも過敏に反応し、「顔認証・手のひら静脈認証」が起動してしまうことが分かり、ユーザーの皆様の電池がすぐに減ってしまう主な原因でした。</b>
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/RadarDistanceGraphFace.png"></a>
 
 </code></pre>


### PR DESCRIPTION
Correct the weekday for 2026-06-27 and add important notes about Face2 radar parameter changes. Added a new bolded item announcing radar parameter tuning to match SesameOS and expanded the existing item with details: parameters re-tuned for ESD-treated radar, curve linearized, resolved rare self-excitation within 1m, and reduced false activations caused by slight grass/wind movement that led to battery drain.