### PR TITLE
Fix spacing in changelog entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -97,7 +97,7 @@
 <b>2026年6月27日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(6??)-??????? @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(8??)-??????? @Github</u></a>
-<b>1.【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
+<b>1. 【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
 2. SesameBot2、SesameBike2における履歴の通知機能が完成。
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/SesameBot2_Bike2_Bike3HistoryNotificationOniOSandroid.png"></a>
 


### PR DESCRIPTION
Add a space after the list number in changelog.html (change '<b>1.【' to '<b>1. 【') to improve readability of the entry. No functional changes.