### PR TITLE
Add 'Sesame Face 2 Pro' to changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -102,7 +102,7 @@
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/SesameBot2_Bike2_Bike3HistoryNotificationOniOSandroid.png"></a>
 
 
-<u>Sesame Face Pro</u>
+<u>Sesame Face Pro / Sesame Face 2 Pro</u>
  3.0-18-dec54c
 <u>Sesame Face</u>
  3.0-19-dec54c
@@ -179,7 +179,7 @@
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/OpenSensorHisotryPage_iOS.png"></a>
 
 
-<u>Sesame Face Pro</u>
+<u>Sesame Face Pro / Sesame Face 2 Pro</u>
  3.0-18-3ca817
 <u>Sesame Face</u>
  3.0-19-3ca817
@@ -389,7 +389,7 @@ AndroidアプリのUIコードレビューを実施し、大規模なリファ�
  3.0-14-b08636
 <u>Remote nano</u>
  3.0-15-b08636
-<u>Sesame Face Pro</u>
+<u>Sesame Face Pro / Sesame Face 2 Pro</u>
  3.0-18-323190
 <u>Sesame Face</u>
  3.0-19-323190
@@ -474,7 +474,7 @@ SesameBot2 の台本の名称と並び順が変更できるようになりまし
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/BLETX_iOSandroid.png"></a>
 
 
-<u>Sesame Face Pro</u>
+<u>Sesame Face Pro / Sesame Face 2 Pro</u>
  3.0-18-f5b193
 <u>Sesame Face</u>
  3.0-19-f5b193


### PR DESCRIPTION
Update changelog.html to include 'Sesame Face 2 Pro' alongside 'Sesame Face Pro' in several release entries for clearer product naming. This is a documentation-only change and does not affect application code or behavior.