### PR TITLE
Update changelog build identifiers for apps

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -95,8 +95,8 @@
 <h2 id="changelog">Change Log 変更履歴</h2>
 <pre><code>
 <b>2026年6月27日(土)</b>
-<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(6??)-??????? @TestFlight</u></a>
-<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(8??)-??????? @Github</u></a>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(651)-b831b0f @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(827)-45d71e41e @Github</u></a>
 <b>1.
 【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
 2.


### PR DESCRIPTION
Update changelog entry (2026-06-27) to replace placeholder build metadata with concrete iOS and Android build identifiers: iOS 3.0.147(651)-b831b0f @TestFlight and Android 3.0.266(827)-45d71e41e @Github. Links remain unchanged; this is a documentation-only update.