### PR TITLE
Add Gradle 9.6.0 update to changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -97,9 +97,10 @@
 <b>2026年6月27日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(651)-b831b0f @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(827)-45d71e41e @Github</u></a>
-<b>1.
+1.【Android app】Gradleを最新バージョン（9.6.0）へアップデートしました。
+<b>2.
 【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
-2.
+3.
 SesameBot2、SesameBike2における履歴の通知機能が完成。6年前にやっておくべきことでした。
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/SesameBot2_Bike2_Bike3HistoryNotificationOniOSandroid.png"></a>
 


### PR DESCRIPTION
Updated the 2026-06-27 changelog entry to include a new Android app note about upgrading Gradle to version 9.6.0, and renumbered the following items to keep the release notes consistent.