### PR TITLE
Update Android app version in changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -96,7 +96,7 @@
 <pre><code>
 <b>2026年6月27日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(651)-b831b0f @TestFlight</u></a>
-<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(827)-45d71e41e @Github</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(828)-ba01aa247 @Github</u></a>
 1.【Android app】Gradleを最新バージョン（9.6.0）へアップデートしました。
 <b>2.
 【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>


### PR DESCRIPTION
Update Android app release version from 3.0.266(827)-45d71e41e to 3.0.266(828)-ba01aa247 in the changelog for the 2026年6月27日 release.