### PR TITLE
Add platform tags to changelog entries

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -99,9 +99,9 @@
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(828)-ba01aa247 @Github</u></a>
 1.【Android app】Gradleを最新バージョン（9.6.0）へアップデートしました。
 <b>2.
-【重要アップデート】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
+【重要アップデート】【Android app & iOS app】Face2シリーズ搭載のSesameOSに合わせたレーダーパラメータ値の調整。</b>
 3.
-SesameBot2、SesameBike2における履歴の通知機能が完成。6年前にやっておくべきことでした。
+【Android app & iOS app】SesameBot2、SesameBike2における履歴の通知機能が完成。6年前にやっておくべきことでした。
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/SesameBot2_Bike2_Bike3HistoryNotificationOniOSandroid.png"></a>
 
 


### PR DESCRIPTION
Updated two changelog entries to clarify that the Face2 radar parameter adjustments and SesameBot2/SesameBike2 history notification features apply to both Android app and iOS app.