### PR TITLE
Document fingerprint change rollback

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -94,6 +94,28 @@
 <p><br><br><br></p>
 <h2 id="changelog">Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年6月29日(月)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.146(647)-0b9be93 @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(824)-170d6efdd @Github</u></a>
+<u>Sesame Face Pro / Sesame Face 2 Pro</u>
+ 3.0-18-5572d8
+<u>Sesame Face</u>
+ 3.0-19-5572d8
+<u>Sesame Face Pro AI時代版</u>
+ 3.0-22-5572d8
+<u>Sesame Face AI時代版</u>
+ 3.0-23-5572d8
+<u>Sesame Touch Pro / Sesame Touch 2 Pro</u>
+ 3.0-9-5572d8
+<u>Sesame Touch / Sesame Touch 2</u>
+ 3.0-10-5572d8
+1. 
+2026年6月27日(土)の上記製品の指紋認証に関連するプログラム変更を元に戻して、変更を取り消します。🙇🏻‍♂️🙏
+理由：<a href="https://www.facebook.com/groups/Sesame.JP/permalink/2038481123443138/" target="_blank"><u>https://www.facebook.com/groups/Sesame.JP/permalink/2038481123443138/</u></a>
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年6月27日(土)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.147(651)-b831b0f @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(828)-ba01aa247 @Github</u></a>
@@ -118,9 +140,9 @@
 <u>Sesame Touch / Sesame Touch 2</u>
  3.0-10-dec54c
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/LEDoffWhenFingerprintIsRead.gif"></a>
-1. 
+<span style="color: #e3e3e3;"><s>1. 
 上記製品の指紋認証において、指紋の読み取り完了の瞬間にLEDを消灯してユーザーにお知らせし、待ち時間を短縮するよう改善しました。
-左:改善後 / 右:改善前。3年前に再調査すべきことでした。
+左:改善後 / 右:改善前。3年前に再調査すべきことでした。</s></span> 2026年6月29日(月)のアップデートにて、以前の状態に戻し、今回の変更を取り消します。🙇🏻‍♂️🙏
 <b>2. 
 【重要アップデート】2026年6月6日(土)の修正に続き、統一した関数を用いて「BLE接続の初期化」と「アドバタイズの開始」を一元管理するようにしました。
 これにより、上記機種におけるBluetoothの未アドバタイズ・未接続の不具合を完璧に修正できたかと存じます。


### PR DESCRIPTION
Update changelog.html with a new June 29, 2026 release entry for iOS/Android and affected Sesame Face/Touch firmware versions. It explicitly announces reverting the June 27 fingerprint-related behavior change, links to the public explanation, and marks the original June 27 fingerprint improvement note as canceled with a rollback note.