### PR TITLE
Update changelog app build versions

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -95,8 +95,8 @@
 <h2 id="changelog">Change Log 変更履歴</h2>
 <pre><code>
 <b>2026年6月29日(月)</b>
-<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.146(647)-0b9be93 @TestFlight</u></a>
-<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(824)-170d6efdd @Github</u></a>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.148(653)-cc5b3b3 @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(829)-7427ede3f @Github</u></a>
 <u>Sesame Face Pro / Sesame Face 2 Pro</u>
  3.0-18-5572d8
 <u>Sesame Face</u>


### PR DESCRIPTION
Refresh the June 29, 2026 changelog entries with the latest mobile app builds: iOS TestFlight 3.0.148(653)-cc5b3b3 and Android GitHub 3.0.266(829)-7427ede3f.