### PR TITLE
Update changelog entries with 一旦 clarification

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -110,7 +110,7 @@
 <u>Sesame Touch / Sesame Touch 2</u>
  3.0-10-5572d8
 1. 
-2026年6月27日(土)の上記製品の指紋認証に関連するプログラム変更を元に戻して、変更を取り消します。🙇🏻‍♂️🙏
+一旦、2026年6月27日(土)の上記製品の指紋認証に関連するプログラム変更を元に戻して、変更を取り消します。🙇🏻‍♂️🙏
 理由：<a href="https://www.facebook.com/groups/Sesame.JP/permalink/2038481123443138/" target="_blank"><u>https://www.facebook.com/groups/Sesame.JP/permalink/2038481123443138/</u></a>
 
 </code></pre>
@@ -140,7 +140,7 @@
 <u>Sesame Touch / Sesame Touch 2</u>
  3.0-10-dec54c
 <img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/LEDoffWhenFingerprintIsRead.gif"></a>
-2026年6月29日(月)のアップデートにて、上記製品の指紋認証に関連するプログラム変更を以前の状態に戻し、今回の変更を取り消します。🙇🏻‍♂️🙏
+2026年6月29日(月)のアップデートにて、一旦、上記製品の指紋認証に関連するプログラム変更を以前の状態に戻し、今回の変更を取り消します。🙇🏻‍♂️🙏
 <span style="color: #e3e3e3;"><s>1. 
 上記製品の指紋認証において、指紋の読み取り完了の瞬間にLEDを消灯してユーザーにお知らせし、待ち時間を短縮するよう改善しました。
 左:改善後 / 右:改善前。3年前に再調査すべきことでした。</s></span>


### PR DESCRIPTION
Add '一旦' (temporarily) to two changelog entries for Sesame Touch / Sesame Touch 2 to clarify that the fingerprint authentication program changes are being reverted temporarily.