### PR TITLE
Add July 4, 2026 changelog entry

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -94,6 +94,21 @@
 <p><br><br><br></p>
 <h2 id="changelog">Change Log 変更履歴</h2>
 <pre><code>
+<b>2026年7月4日(土)</b>
+<a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.149(656)-38044cc @TestFlight</u></a>
+<a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(834)-c324fef0f @Github</u></a>
+1. 
+【Android app & iOS app】
+アプリ内に同梱していたすべての「組み込みSesameOS.zip」を削除し、クラウドからリアルタイムでダウンロードする方式へ変更し、大幅なコードの削減によりアプリのメンテナンスコストを低減いたしました。
+これにより、Apple / Google の審査を待つことなく、当日中に最新の組み込みSesameOS.zipを即座に配信できるようになりました。
+また、本変更に伴い、SesameOS.zip更新後にUI上の赤いびっくりマーク❗️が消えない問題も併せて無くなりました。
+更に、仮に2026年6月29日（月）に、同年6月27日（土）版の不具合を緊急修正するようなケースにおいても、今後は数日間に及ぶアプリ審査を待つ必要はなく、10分以内に「即修正・即配信」ができるようになります。
+今後もイテレーションのサイクルをさらに加速し、スピーディーな開発をお届けして参ります！
+<img src="https://cdn.shopify.com/s/files/1/0016/1870/6495/files/DFUzipFromCloud_iOS_android.png"></a>
+
+</code></pre>
+<hr>
+<pre><code>
 <b>2026年6月29日(月)</b>
 <a href="https://testflight.apple.com/join/Rok4GOFD/" target="_blank"><u>iOS app 3.0.148(653)-cc5b3b3 @TestFlight</u></a>
 <a href="https://github.com/CANDY-HOUSE/SesameSDK_Android_with_DemoApp/releases/latest/download/Sesame_android_release.apk"><u>Android app 3.0.266(829)-7427ede3f @Github</u></a>


### PR DESCRIPTION
Adds a new changelog section for the iOS and Android app releases (3.0.149/3.0.266). The note explains the shift from bundled SesameOS.zip files to real-time cloud downloads, reducing app size/maintenance and enabling same-day OS zip updates and faster emergency fixes without waiting for app store review.